### PR TITLE
Release 3.3.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,23 +15,23 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "AdyenPOSTEST",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/209888053.zip",
-            checksum: "1550ca2e9338ebdd175ddaf769516485f90be785cbcf85567a1163adef9af5ed"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399087.zip",
+            checksum: "c0755eca1517cd62cddb99716bd91d18f57aac27700966403cb38b566851b0e0"
         ),
         .binaryTarget(
             name: "ADYPOSTEST",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/209888058.zip",
-            checksum: "0fa157fc47a74cd165b4b88f96b6d9292c2d1eb8d13b1b1365189eea72fa246e"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399096.zip",
+            checksum: "1fb439617205f2d6223ee67006791b734d42aaf88f4a33502803e7ae7aa4de26"
         ),
         .binaryTarget(
             name: "AdyenPOSLIVE",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/209888047.zip",
-            checksum: "33590ddd062401f84e21f4b46c118c91124f629bfe985289650f804f0c30fb98"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399077.zip",
+            checksum: "e70a39b26cbc3ece881a755b920897f11364a3904173f064af4ab7558240c17c"
         ),
         .binaryTarget(
             name: "ADYPOSLIVE",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/209888052.zip",
-            checksum: "a3d70b347b88cd1d239afe104ef6ee3621cf3b7dae4aa7097993b7e9d3846d32"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399082.zip",
+            checksum: "9fb070410eb3c08eec8681344e9f30855be5e7f43743c0acde78fe04125c0b87"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The repository contains a small sample app which can be used to get started with
 See our documentation on [docs.adyen.com](https://docs.adyen.com/point-of-sale/ipp-mobile/)
 
 ### Developer  Documentation
-For developer documentation, you can use the above link, or if you prefer the Apple docc format, you can find it [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.3.1/documentation/adyenpos/adyenpos)
+For developer documentation, you can use the above link, or if you prefer the Apple docc format, you can find it [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.3.2/documentation/adyenpos/adyenpos)
 
 ### Tutorials
 You can also view a step by step tutorial which will walk you through how to integrate the SDK for both TapToPay and NYC1.
-Find the tutorials [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.3.1/tutorials/meet-adyenpos/)
+Find the tutorials [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.3.2/tutorials/meet-adyenpos/)
 
 
 ## Support


### PR DESCRIPTION
Release notes:

⚠️ SDK NYC1 PIN support expires on June 28 2025 ⚠️
### Fixed:
- Fixed an issue where NYC1 Store & Forward transactions would fail after updating the SDK from 3.2.0 to 3.3.x. Please update to version 3.3.2 to ensure S&F transactions work on NYC1.
- In some cases when executing a firmware update on NYC1, the SDK reported success while the device was not actually updated. In this version, an error will be thrown when the firmware is not the expected version after an update.
