### PR TITLE
Release 3.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,23 +15,23 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "AdyenPOSTEST",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399087.zip",
-            checksum: "c0755eca1517cd62cddb99716bd91d18f57aac27700966403cb38b566851b0e0"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/222478150.zip",
+            checksum: "fafe644aef30798624b1570b1f353150a58d0cc7a9f55ce7a11822c672603ce7"
         ),
         .binaryTarget(
             name: "ADYPOSTEST",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399096.zip",
-            checksum: "1fb439617205f2d6223ee67006791b734d42aaf88f4a33502803e7ae7aa4de26"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/222478188.zip",
+            checksum: "6bdc7cfbe049f8a32cd26b685c86e8221a81fd5122997c93e0b7077a27e6a106"
         ),
         .binaryTarget(
             name: "AdyenPOSLIVE",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399077.zip",
-            checksum: "e70a39b26cbc3ece881a755b920897f11364a3904173f064af4ab7558240c17c"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/222478126.zip",
+            checksum: "81a2491aeb5de53a74ec809d9237da0353283262e25b31ad8122beed151a3a59"
         ),
         .binaryTarget(
             name: "ADYPOSLIVE",
-            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/217399082.zip",
-            checksum: "9fb070410eb3c08eec8681344e9f30855be5e7f43743c0acde78fe04125c0b87"
+            url: "https://api.github.com/repos/Adyen/adyen-pos-mobile-ios-artifacts/releases/assets/222478143.zip",
+            checksum: "c47911815ba21a821968b363b6cd17c513188327a87d3c283b8a7902d3d50968"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The repository contains a small sample app which can be used to get started with
 See our documentation on [docs.adyen.com](https://docs.adyen.com/point-of-sale/ipp-mobile/)
 
 ### Developer  Documentation
-For developer documentation, you can use the above link, or if you prefer the Apple docc format, you can find it [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.3.2/documentation/adyenpos/adyenpos)
+For developer documentation, you can use the above link, or if you prefer the Apple docc format, you can find it [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.4.0/documentation/adyenpos/adyenpos)
 
 ### Tutorials
 You can also view a step by step tutorial which will walk you through how to integrate the SDK for both TapToPay and NYC1.
-Find the tutorials [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.3.2/tutorials/meet-adyenpos/)
+Find the tutorials [here](https://adyen.github.io/adyen-pos-mobile-ios-artifacts/3.4.0/tutorials/meet-adyenpos/)
 
 
 ## Support


### PR DESCRIPTION
⚠️ SDK NYC1 PIN support expires on July 12, 2025  ⚠️

### New:

- Various security and internal observability improvements.

### Fixed:

- Resolved an issue that could cause transactions to temporarily fail when running on the simulator.

### Known Issues:

- Attempting to perform NYC1 PIN transactions on the same NYC1 using different versions of the SDK may result in a failure until the session is reset.